### PR TITLE
Update Anti-Fingerprinting-List.txt

### DIFF
--- a/Attributed/Cybo1927/Anti-Fingerprinting-List.txt
+++ b/Attributed/Cybo1927/Anti-Fingerprinting-List.txt
@@ -12,7 +12,8 @@
 ! =======================================================================================================================================
 ! Prevent browser fingerprinting some JavaScript APIs.
 ! Navigator API
-! com,net#%#Object.defineProperty(navigator, 'plugins', { get: function() { return '0'; } });
+! com,net#%#Object.defineProperty(navigator, 'plugins', { get: function() { return 0; } });
+! com,net#%#Object.defineProperty(navigator, 'mimeTypes', { get: function() { return 0; } });
 ! com,net#%#Object.defineProperty(navigator, 'appCodeName', { get: function() { return 'Mozilla'; } });
 ! com,net#%#Object.defineProperty(navigator, 'appName', { get: function() { return 'Netscape'; } });
 ! com,net#%#Object.defineProperty(navigator, 'appVersion', { get: function() { return 'Mozilla/5.0 (Android 9.0; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0'; } });


### PR DESCRIPTION
For some reason using '0' instead of 0 breaks some other browser APIs, added faking for mimeTypes